### PR TITLE
Added option to choose dependency source for BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Example usage:
                                     <newScope>runtime</newScope>
                                 </scopeOverride>
                             </scopeOverrides>
+                            <!-- Choose dependency source DEPENDENCY_MANAGEMENT (default) or PROJECT_DEPENDENCIES for the bom -->
+                            <dependencySource>DEPENDENCY_MANAGEMENT</dependencySource>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,31 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>3.2.2</version>
+          <configuration>
+            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+            <debug>true</debug>
+            <settingsFile>src/it/settings.xml</settingsFile>
+            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+            <pomIncludes>
+              <pomInclude>*/pom.xml</pomInclude>
+            </pomIncludes>
+            <projectsDirectory>src/it</projectsDirectory>
+            <postBuildHookScript>verify</postBuildHookScript>
+          </configuration>
+          <executions>
+            <execution>
+              <id>run-invoker</id>
+              <goals>
+                <goal>run</goal>
+              </goals>
+              <phase>integration-test</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/src/it/dependencies-pom/pom.xml
+++ b/src/it/dependencies-pom/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.wildfly.plugins.test</groupId>
+  <artifactId>dependencies-pom</artifactId>
+  <version>@pom.version@</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.14.0</version>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.14.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-bom-builder-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <id>build-bom</id>
+            <goals>
+              <goal>build-bom</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bomGroupId>org.wildfly.plugins.test</bomGroupId>
+          <bomArtifactId>dependencies-pom</bomArtifactId>
+          <bomVersion>$@pom.version@</bomVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/dependencies-pom/verify.groovy
+++ b/src/it/dependencies-pom/verify.groovy
@@ -1,0 +1,33 @@
+/*
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+*/
+
+File file = new File(basedir, "target/bom-pom.xml")
+def line
+def foundDependency = false
+file.withReader { reader ->
+  while ((line = reader.readLine())!=null) {
+    if (line.contains("<artifactId>commons-lang3</artifactId>")) {
+      foundDependency = true
+      break
+    }
+  }
+}
+if (!foundDependency) {
+  println("VERIFY ERROR: bom-pom.xml does not contain commons-lang3 dependency!")
+  return false
+}
+
+

--- a/src/it/dependency-management-pom/pom.xml
+++ b/src/it/dependency-management-pom/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@pom.groupId@</groupId>
+  <artifactId>dependency-management-pom</artifactId>
+  <version>@pom.version@</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.14.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.12.0</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <!-- should be excluded -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-bom-builder-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <id>build-bom</id>
+            <goals>
+              <goal>build-bom</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bomGroupId>@pom.groupId@</bomGroupId>
+          <bomArtifactId>dependency-management-pom</bomArtifactId>
+          <bomVersion>$@pom.version@</bomVersion>
+          <excludeDependencies>
+            <dependency>
+              <groupId>*</groupId>
+              <artifactId>*</artifactId>
+              <scope>provided</scope>
+            </dependency>
+          </excludeDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/dependency-management-pom/verify.groovy
+++ b/src/it/dependency-management-pom/verify.groovy
@@ -1,0 +1,38 @@
+/*
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+*/
+
+File file = new File(basedir, "target/bom-pom.xml")
+def line
+def foundDependency1 = false
+def foundDependency2 = false
+file.withReader { reader ->
+  while ((line = reader.readLine())!=null) {
+    if (line.contains("<artifactId>commons-lang3</artifactId>")) {
+      foundDependency1 = true
+    }
+    if (line.contains("<artifactId>commons-text</artifactId>")) {
+      foundDependency2 = true
+    }
+  }
+}
+if (!foundDependency1) {
+  println("VERIFY ERROR: bom-pom.xml does not contain commons-lang3 dependency!")
+  return false
+}
+if (foundDependency2) {
+  println("VERIFY ERROR: bom-pom.xml should not contain commons-text dependency!")
+  return false
+}

--- a/src/it/multi-module-pom/invoker.properties
+++ b/src/it/multi-module-pom/invoker.properties
@@ -1,0 +1,1 @@
+invoker.project = module1

--- a/src/it/multi-module-pom/module1/pom.xml
+++ b/src/it/multi-module-pom/module1/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>@pom.groupId@</groupId>
+    <artifactId>multi-module-pom</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>module1</artifactId>
+  <version>@pom.version@</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+
+    <!-- included -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <!-- included -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <!-- excluded because of provided scope  -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.16.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.12.0</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+
+</project>

--- a/src/it/multi-module-pom/module2/pom.xml
+++ b/src/it/multi-module-pom/module2/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>@pom.groupId@</groupId>
+    <artifactId>multi-module-pom</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>module2</artifactId>
+  <version>@pom.version@</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/multi-module-pom/module3/pom.xml
+++ b/src/it/multi-module-pom/module3/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>@pom.groupId@</groupId>
+    <artifactId>multi-module-pom</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>module3</artifactId>
+  <version>@pom.version@</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/multi-module-pom/pom.xml
+++ b/src/it/multi-module-pom/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@pom.groupId@</groupId>
+  <artifactId>multi-module-pom</artifactId>
+  <version>@pom.version@</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module1</module>
+    <module>module2</module>
+    <module>module3</module>
+  </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.14.0</version>
+      </dependency>
+      <!-- not used in module 1 -->
+      <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <version>1.9.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-bom-builder-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <id>build-bom</id>
+            <goals>
+              <goal>build-bom</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bomGroupId>@pom.groupId@</bomGroupId>
+          <bomArtifactId>multi-module-pom</bomArtifactId>
+          <bomVersion>$@pom.version@</bomVersion>
+          <!-- get dependencies from project dependencies instead of dependencies management -->
+          <dependencySource>PROJECT_DEPENDENCIES</dependencySource>
+          <excludeDependencies>
+            <dependency>
+              <groupId>*</groupId>
+              <artifactId>*</artifactId>
+              <scope>provided</scope>
+            </dependency>
+          </excludeDependencies>
+          <scopeOverrides>
+            <scopeOverride>
+              <groupId>*</groupId>
+              <artifactId>*</artifactId>
+              <scope>compile</scope>
+              <newScope>provided</newScope>
+            </scopeOverride>
+          </scopeOverrides>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/multi-module-pom/verify.groovy
+++ b/src/it/multi-module-pom/verify.groovy
@@ -1,0 +1,62 @@
+/*
+  ~ Copyright (C) 2013 Red Hat, Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+*/
+
+File file = new File(basedir, "module1/target/bom-pom.xml")
+def line
+def foundDependency1 = false
+def foundDependency2 = false
+def foundDependency3 = false
+def foundDependency4 = false
+def providedCount = 0
+file.withReader { reader ->
+  while ((line = reader.readLine())!=null) {
+    if (line.contains("<artifactId>commons-lang3</artifactId>")) {
+      foundDependency1 = true
+    }
+    if (line.contains("<artifactId>commons-io</artifactId>")) {
+      foundDependency2 = true
+    }
+    if (line.contains("<artifactId>commons-cli</artifactId>")) {
+      foundDependency3 = true
+    }
+    if (line.contains("<artifactId>commons-text</artifactId>")) {
+      foundDependency4 = true
+    }
+    if (line.contains("<scope>provided</scope>")) {
+      providedCount = providedCount + 1
+    }
+  }
+}
+if (!foundDependency1) {
+  println("VERIFY ERROR: bom-pom.xml does not contain commons-lang3 dependency!")
+  return false
+}
+if (!foundDependency2) {
+  println("VERIFY ERROR: bom-pom.xml does not contain commons-io dependency!")
+  return false
+}
+if (foundDependency3) {
+  println("VERIFY ERROR: bom-pom.xml should not contain commons-cli dependency!")
+  return false
+}
+if (foundDependency4) {
+  println("VERIFY ERROR: bom-pom.xml should not contain commons-text dependency!")
+  return false
+}
+if (providedCount != 2) {
+  println("VERIFY ERROR: bom-pom.xml should contain 2 dependencies with provided scope!")
+  return false
+}

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>it-repo</activeProfile>
+  </activeProfiles>
+</settings>
+

--- a/src/main/java/org/wildfly/plugins/bombuilder/DependencySource.java
+++ b/src/main/java/org/wildfly/plugins/bombuilder/DependencySource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bombuilder;
+
+public enum DependencySource
+{
+    /**
+     * Dependencies from dependency management.
+     */
+    DEPENDENCY_MANAGEMENT,
+    /**
+     * Project dependencies.
+     */
+    PROJECT_DEPENDENCIES;
+}


### PR DESCRIPTION
There is a problem when creating BOM for module in multi module project. If for example dependency is included in parent project dependency management and not used by module for which you want to create BOM, then unused dependency will be included into bom-pom.xml I've added integration test `src/it/multi-module-pom` to illustrate this problem.

PS. To run integration tests hit `mvn clean install invoker:run`
